### PR TITLE
fix docker-compose for hydroserver installation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -127,12 +127,14 @@ services:
 
   hs_django:
     container_name: hs_django
-    <<: *standard
-    <<: *body
-    <<: *standardcommand
+    <<: 
+    - *standard
+    - *body
+    - *standardcommand
     restart: unless-stopped
-    hs_postgresql:
-      condition: service_started
+    depends_on:
+      hs_postgresql:
+        condition: service_started
 
   hs_nodejs:
     environment:
@@ -156,9 +158,6 @@ services:
     restart: unless-stopped
     container_name: hs_nginx
     image: nginx:latest
-    links:
-      - hs_nodejs
-      - hs_django
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
       - staticfiles:/staticfiles


### PR DESCRIPTION
Fixes: https://github.com/Groupeffect/hydroserver-podman/issues/2
I think "links" tag are outdated in docker compose. With this system I can launch hydroserver.